### PR TITLE
Restrict data container validation to disallow extra parameters

### DIFF
--- a/pysvg/components/matrix.py
+++ b/pysvg/components/matrix.py
@@ -1,12 +1,12 @@
-from typing import Tuple, Literal
 from pathlib import Path
+from typing import Literal, Tuple
 
-from pysvg.schema import AppearanceConfig, TransformConfig, Color, SVGCode
-from pysvg.components.base import BaseSVGComponent
+from pydantic import ConfigDict, Field
+
+from pysvg.components.base import BaseSVGComponent, BaseSVGConfig
 from pysvg.components.cell import Cell, CellConfig
-from pysvg.components.content import TextConfig, ImageConfig, SVGConfig, TextContent
-from pydantic import BaseModel, Field
-
+from pysvg.components.content import ImageConfig, SVGConfig, TextConfig, TextContent
+from pysvg.schema import AppearanceConfig, Color, SVGCode, TransformConfig
 
 # Define matrix element data type
 MatElemType = str | int | float | Path | SVGCode
@@ -15,8 +15,10 @@ MatElemType = str | int | float | Path | SVGCode
 BorderPosition = Literal["upperleft", "upperright", "lowerleft", "lowerright"]
 
 
-class MatrixConfig(BaseModel):
+class MatrixConfig(BaseSVGConfig):
     """Matrix component configuration"""
+
+    model_config = ConfigDict(extra="forbid")
 
     x: float = Field(default=0, description="Matrix x position")
     y: float = Field(default=0, description="Matrix y position")

--- a/pysvg/schema/color.py
+++ b/pysvg/schema/color.py
@@ -1,12 +1,21 @@
 import re
 
-from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    field_validator,
+    model_serializer,
+    model_validator,
+    ConfigDict,
+)
 
 from pysvg.constants import SVG_NONE
 
 
 class Color(BaseModel):
     """SVG color type that supports multiple color formats"""
+
+    model_config = ConfigDict(extra="forbid")
 
     value: str = Field(..., description="Color value")
 

--- a/pysvg/schema/svg_code.py
+++ b/pysvg/schema/svg_code.py
@@ -1,8 +1,10 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class SVGCode(BaseModel):
     """SVG or SVG content component code"""
+
+    model_config = ConfigDict(extra="forbid")
 
     code: str = Field(description="SVG code")
 

--- a/pysvg/schema/svg_config.py
+++ b/pysvg/schema/svg_config.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Literal, Tuple, Union
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing_extensions import override
 
 from pysvg.constants import SVG_NONE
@@ -10,6 +10,8 @@ from .color import Color
 
 class BaseSVGConfig(BaseModel):
     """Base configuration for SVG graphics"""
+
+    model_config = ConfigDict(extra="forbid")
 
     def to_svg_dict(self) -> dict[str, Any]:
         attrs = self.model_dump(exclude_none=True)


### PR DESCRIPTION
Change the validation mode of data containers to strictly enforce parameter validation by rejecting any extra/unknown parameters. This ensures better data integrity and prevents potential issues from unintended parameter usage.